### PR TITLE
Turn on GitHub actions

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,3 +10,4 @@
 ^R-CMD-check_badge\.svg$
 ^R-CMD-check_output\.txt$
 ^sandbox$
+^\.github$

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Build the package
-        run: make install
+        run: make install-with-deps
 
 ### ** test
           
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Build the package
-        run: make install
+        run: make install-with-deps
       - name: Test the package
         run: make test
       - name: Determine coverage
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Build the package
-        run: make install
+        run: make install-with-deps
       - name: Check the package (R CMD check)
         run: |
           make check
@@ -79,7 +79,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Build the package
-        run: make install
+        run: make install-with-deps
       - name: Build the pkgdown website
         run: |
           make pkgdown

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -1,0 +1,129 @@
+### * Resources:
+
+# - https://github.com/maxheld83/ghactions
+# - https://github.com/r-lib/actions/tree/master/examples
+
+### * Setup
+
+name: pipeline
+on:
+  push:
+    branches:
+      - master
+
+### * Jobs
+      
+jobs:
+
+### ** build
+  
+  build:
+    runs-on: ubuntu-latest
+    container: rocker/verse
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build the package
+        run: make install
+
+### ** test
+          
+  test:
+    runs-on: ubuntu-latest
+    container: rocker/verse
+    needs: build
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build the package
+        run: make install
+      - name: Test the package
+        run: make test
+      - name: Determine coverage
+        run: |
+          R -e 'install.packages("here")'
+          make coverage
+          mv docs/coverage .
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: test-coverage
+          path: ./coverage/
+
+### ** check
+        
+  check:
+    runs-on: ubuntu-latest
+    container: rocker/verse
+    needs: build
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build the package
+        run: make install
+      - name: Check the package (R CMD check)
+        run: |
+          make check
+          mkdir -p check-results/
+          mv R-CMD-check_badge.svg R-CMD-check_output.txt check-results/
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: check-results
+          path: ./check-results/
+
+### ** pkgdown
+        
+  pkgdown:
+    runs-on: ubuntu-latest
+    container: rocker/verse
+    needs: [test, check]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build the package
+        run: make install
+      - name: Build the pkgdown website
+        run: |
+          make pkgdown
+          cp .update-gh-pages.sh docs/
+      - uses: actions/download-artifact@v1
+        with:
+          name: test-coverage
+          path: ./coverage
+      - name: Add coverage results
+        run: mv coverage/ docs/
+      - uses: actions/download-artifact@v1
+        with:
+          name: check-results
+          path: ./check-results
+      - name: Add check results
+        run: mv check-results/ docs/
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: pkgdown-docs
+          path: ./docs/
+    
+### ** update-gh-pages
+
+  update-gh-pages:
+    runs-on: ubuntu-latest
+    needs: pkgdown
+    steps:
+      - uses: actions/checkout@v1
+      - run: git checkout gh-pages
+      - run: |
+          pwd
+          ls
+          rm -fr ./*
+          ls
+          git branch -a
+      - uses: actions/download-artifact@v1
+        with:
+          name: pkgdown-docs
+          path: .
+      - run: |
+          pwd
+          ls
+          git branch -a
+          cat .update-gh-pages.sh
+          bash .update-gh-pages.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -10,6 +10,7 @@ on:
   push:
     branches:
       - master
+      - turn-on-github-actions
 
 ### * Jobs
       

--- a/.update-gh-pages.sh
+++ b/.update-gh-pages.sh
@@ -1,0 +1,23 @@
+# Modified from https://www.innoq.com/en/blog/github-actions-automation/
+
+set -eu
+echo "Starting bash script"
+
+repo_uri="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+git config user.name "$GITHUB_ACTOR"
+git config user.email "${GITHUB_ACTOR}@bots.github.com"
+
+echo "Adding files"
+git add --force .
+
+echo "Committing files"
+git commit -m "Updated GitHub pages"
+if [ $? -ne 0 ]; then
+    echo "Nothing to commit"
+    exit 0
+fi
+
+echo "Pushing to gh-pages"
+git remote set-url origin "$repo_uri"
+git push --force origin gh-pages

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,24 @@ install: document
 	@printf "\n"
 	@printf "$(GREEN)*** Installing the package ***$(NC)\n"
 	@printf "\n"
-	@ Rscript -e 'devtools::install(upgrade = FALSE)'
+	@Rscript -e 'devtools::install(upgrade = FALSE)'
+
+### ** install-deps
+
+## install-deps : install dependencies needed for CI pipelines
+.PHONY: install-deps
+install-deps:
+	@printf "\n"
+	@printf "$(GREEN)*** Installing dependencies for continuous integration pipelines ***$(NC)\n"
+	@printf "\n"
+	@Rscript -e 'install.packages(c("ape", "readxl", "writexl", "testthat", "stringdist", "qualV", "igraph", "DT"))'
+	@Rscript -e 'install.packages(c("pkgdown", "covr"))'
+
+### ** install-with-deps
+
+## install-with-deps : run 'install-deps' and 'install'
+.PHONY: install-with-deps
+install-with-deps: install-deps install
 
 ### ** pkgdown
 


### PR DESCRIPTION
I added the necessary files to use GitHub Actions to automatically build the pkgdown website and publish it when the repo is updated. The files defining GitHub actions are stored in `./.github/workflows/`, and for now there is only one, `github-ci.yml`.

The file `github-ci.yml` is written so that it sequentially builds the package, runs tests and R CMD check, and then builds the pkgdown website. If everything runs successfully, it will automatically update the repo's `gh-pages` branch with the content of the pkgdown website. The `gh-pages` branch is the repo branch that GitHub uses by default to serve the webpages for a GitHub project.

So in summary, the concatipede repo on GitHub will have at least two branches:
- `master`, which contains the actual R package
- `gh-pages`, which contains the pkgdown website and which is automatically updated by the GitHub Actions defined in `./.github/workflows/github-ci.yml` when the repo is updated

Things seem to work fine (the GitHub Actions completed succesfully when I pushed to the `turn-on-github-actions` branch), but one last step needs to be done by someone with admin rights to the repo settings: you can turn on the GitHub pages by going to the repo "Settings" tab, section "Pages", and there you can select as the source for the GitHub pages the `gh-pages` branch.

After this, the website should be available at https://tardipede.github.io/concatipede