### PR TITLE
Update links for GitHub

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,4 @@
 ^R-CMD-check_output\.txt$
 ^sandbox$
 ^\.github$
+^\.update-gh-pages\.sh$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: concatipede
-Title: Concatenate multiple sequence alignments based on excel table
+Title: Concatenate multiple sequence alignments based on a correspondence Excel table
 Version: 0.1
 Date: 2021-02-21
 year: 2021
@@ -11,9 +11,13 @@ Authors@R: c(
            comment = c(ORCID = "0000-0002-7995-6827")),
     person(given = "Mattieu",
            family = "Bruneaux",
-           role = c("aut")))
-Description: This package allows to concatenate sequences of multiple MSAs based on a translation table that can be edited in excel.
+           role = c("aut"),
+           email = "matthieu.bruneaux@gmail.com",
+           comment = c(ORCID = "0000-0001-6997-192X")))
+Description: This package allows to concatenate sequences of multiple MSAs based on a correspondence table that can be edited in Excel.
 License: MIT + file LICENSE
+URL: https://github.com/tardipede/concatipede, https://tardipede.github.io/concatipede/
+BugReports: https://github.com/tardipede/concatipede/issues
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![GitLab pipeline status](https://gitlab.com/tardipede/concatipede/badges/master/pipeline.svg)](https://gitlab.com/tardipede/concatipede/commits/master)
-[![R_CMD_CHECK](https://tardipede.gitlab.io/concatipede/R-CMD-check_badge.svg)](https://tardipede.gitlab.io/concatipede/R-CMD-check_output.txt)
+[![GitHub Actions status](https://github.com/tardipede/concatipede/workflows/pipeline/badge.svg)](https://github.com/tardipede/concatipede/actions?workflow=pipeline)
+[![R_CMD_CHECK](https://tardipede.github.io/concatipede/check-results/R-CMD-check_badge.svg)](https://tardipede.github.io/concatipede/check-results/R-CMD-check_output.txt)
 [![Lifecycle Status](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://www.tidyverse.org/lifecycle/)
 
 Concatipede: an R package to concatenate fasta sequences easily  <img src="man/figures/concatipede_hexagon.png" width="120" align="right" />
@@ -22,7 +22,7 @@ Please let us know if you encounter any issues during the package installation!
 
 ## How to use concatipede
 
-You can get started with this [example vignette](https://tardipede.gitlab.io/concatipede/articles/Package-usage.html).
+You can get started with this [example vignette](https://tardipede.github.io/concatipede/articles/Package-usage.html).
 
 ## Contact
 matteo.vecchi15@gmail.com

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -1,13 +1,13 @@
 ### * url
 
-url: https://tardipede.gitlab.io/concatipede/
+url: https://tardipede.github.io/concatipede/
 
 ### * home
 
 home:
   links:
     - text: Browse source code at
-      href: https://gitlab.com/tardipede/concatipede
+      href: https://github.com/tardipede/concatipede
 
 ### * template and toc
       
@@ -30,5 +30,5 @@ navbar:
       href: articles/Package-usage.html
 
   right:
-    - icon: fa fa-gitlab fa-lg
-      href: https://gitlab.com/tardipede/concatipede
+    - icon: fa fa-github fa-lg
+      href: https://github.com/tardipede/concatipede


### PR DESCRIPTION
I updated the links that were pointing to Gitlab previously (including badges) so that they point to GitHub now.

Files modified: `DESCRIPTION`, `README.md`, and `_pkgdown.yml`. I also changed slightly the wording in `DESCRIPTION` for the package description and summary.

I updated `.Rbuildignore` to ignore `.update-gh-pages.sh`.
