### PR TITLE
Modifications related to rhub checks

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,4 @@
 ^\.github$
 ^\.update-gh-pages\.sh$
 ^cran-comments\.md$
+^rhub-check

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,3 +14,4 @@
 ^\.update-gh-pages\.sh$
 ^cran-comments\.md$
 ^rhub-check
+^rhub-report

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ doc
 Meta
 R-CMD-check_badge.svg
 R-CMD-check_output.txt
+rhub-check_*

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ doc
 Meta
 R-CMD-check_badge.svg
 R-CMD-check_output.txt
-rhub-check_*
+rhub-report_*

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,6 @@
 Package: concatipede
-Title: Concatipede: An R Package to Concatenate Fasta Sequences Easily
+Title: Easy Concatenation of Fasta Sequences
 Version: 1.0.0
-Date: 2021-07-24
-Year: 2021
 Authors@R: c(
     person(given = "Matteo",
            family = "Vecchi",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,8 @@ Authors@R: c(
            role = c("aut"),
            email = "matthieu.bruneaux@gmail.com",
            comment = c(ORCID = "0000-0001-6997-192X")))
-Description: This package allows to concatenate sequences of multiple sequence alignments based on a correspondence table that can be edited in Excel <doi:110.5281/zenodo.5130604>.
+Description: Concatenation of multiple sequence alignments based on a
+    correspondence table that can be edited in Excel <doi:10.5281/zenodo.5130604>.
 License: MIT + file LICENSE
 URL: https://github.com/tardipede/concatipede, https://tardipede.github.io/concatipede/
 BugReports: https://github.com/tardipede/concatipede/issues

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,7 @@ clean: clean-man clean-docs clean-vignettes
 	@printf "\n"
 	@printf "$(GREEN)*** Cleaned automatically generated files and folders ***$(NC)\n"
 	@printf "\n"
+	rm -f rhub-check_*
 
 ### ** clean-man
 

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ clean: clean-man clean-docs clean-vignettes
 	@printf "\n"
 	@printf "$(GREEN)*** Cleaned automatically generated files and folders ***$(NC)\n"
 	@printf "\n"
-	rm -f rhub-check_*
+	rm -f rhub-report_*
 
 ### ** clean-man
 

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ citHeader("To cite concatipede in publications use:")
 bibentry(
   bibtype = "Misc",
   doi = "110.5281/zenodo.5130604",
-  url = "https://tardipede.github.io/concatipede",
+  url = "https://tardipede.github.io/concatipede/",
   year = "2021",
   author = "Matteo Vecchi and Matthieau Bruneaux",
   title = "concatipede: an R package to concatenate fasta sequences easily",

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -2,7 +2,7 @@ citHeader("To cite concatipede in publications use:")
 
 bibentry(
   bibtype = "Misc",
-  doi = "110.5281/zenodo.5130604",
+  doi = "10.5281/zenodo.5130604",
   url = "https://tardipede.github.io/concatipede/",
   year = "2021",
   author = "Matteo Vecchi and Matthieau Bruneaux",

--- a/rhub-check.R
+++ b/rhub-check.R
@@ -26,7 +26,6 @@ start_report <- function(name = "rhub-report") {
     name <- paste0(name, "_", format(Sys.time(), "%Y-%m-%d-%H%M%S"), ".md")
     file <- file(here::here(name), open = "w")
     cat("# Rhub check report, started on", format(Sys.time()), "\n", file = file)
-    cat("\n", file = file)
     return(file)
 }
 
@@ -35,7 +34,7 @@ start_report <- function(name = "rhub-report") {
 #' Run a rhub check for one platform and save the report to an open file
 check_and_report <- function(platform, file) {
     run <- check_and_wait(platform = platform)
-    cat("\n## Check for", platform, file = file)
+    cat("\n## Check for", platform, "\n", file = file)
     write_report(run = run, file = file)
 }
 
@@ -43,6 +42,7 @@ check_and_report <- function(platform, file) {
 
 #' Close report file
 close_report <- function(file) {
+    cat("\n# End of report,", format(Sys.time()), "\n", file = file)
     close(file)
 }
 
@@ -54,6 +54,7 @@ close_report <- function(file) {
 check_and_wait <- function(platform) {
     run <- check_for_cran(platform = platform, email = EMAIL, show_status = FALSE)
     completed <- FALSE
+    Sys.sleep(15)
     while (!completed) {
         completed <- tryCatch(run$cran_summary(),
                               error = function(e) {
@@ -96,7 +97,12 @@ targets <- c("fedora-clang-devel",
              "ubuntu-gcc-release")
 
 report <- start_report()
-for (x in targets[2:4]) {
+for (x in targets) {
     check_and_report(platform = x, file = report)
 }
 close_report(report)
+
+### * Alternative check on Windows
+
+# For an alternative check on windows, one can run:
+# devtools::check_win_devel(email = EMAIL)

--- a/rhub-check.R
+++ b/rhub-check.R
@@ -1,0 +1,45 @@
+### * Description
+
+# This script can be used to check the package on various platforms using the rhub package.
+
+# See: https://cran.r-project.org/web/packages/rhub/vignettes/rhub.html
+
+### * Setup
+
+library(here)
+library(crayon)
+library(rhub)
+
+# The first time rhub is used on your machine, you should validate your email
+# with:
+#   validate_email()
+
+### * Check
+
+# List platforms
+platforms()
+
+# Check
+cran_prep <- check(platform = c("fedora-clang-devel",
+                                "windows-x86_64-devel",
+                                "macos-highsierra-release",
+                                "ubuntu-gcc-release"),
+                   email = "matthieu.bruneaux@gmail.com")
+completed <- FALSE
+
+while (!completed) {
+    tryCatch({
+        notes <- cran_prep$cran_summary()
+        completed <- TRUE },
+      error = function(e) {
+          message("Results not ready yet, waiting 60 seconds before next try.")
+          Sys.sleep(60)
+          e
+      })
+}
+
+fo <- here::here(paste0("rhub-check_", format(Sys.time(), "%Y-%m-%d-%H%M%S"), ".md"))
+fo <- file(fo, open = "w")
+cat(strip_style(capture.output(notes$print())), file = fo, sep = "\n")
+cat("\n")
+close(fo)


### PR DESCRIPTION
I added a `rhub-check.R` script at the root of the project. This script can be used to run package checks on several platforms thanks to the rhub servers. It is configured to run the checks on Mac, Windows, and two different Linux platforms. (**Note:** the script has to be run manually (it is not included in the Github pipeline) and the email address where to send the results can be updated in the script.)

Based on the output of rhub checks, I did a few modifications to the repository to avoid as many notes as possible:

- I removed the `Date` and `Year` fields from `DESCRIPTION`.
- I updated the `Title` and `Description` in `DESCRIPTION` to avoid starting with the package name or with "This package...".
- I changed the doi for the Zenodo object in `DESCRIPTION` and `inst/CITATION` (**Matteo, could you double-check that the doi is now correct?**).
- I updated the url in `inst/CITATION` (just adding a trailing `/`).

With those changes, the rhub checks on the four platforms mentioned above only sends minor notes, so the package seems to be ready for submission. The results for the rhub checks can be mentioned in the `cran-comments.md` file (cf. https://r-pkgs.org/release.html#release-process). Below are the results generated by running `rhub-check.R`:

# Rhub check report, started on 2021-07-31 22:05:50 

## Check for fedora-clang-devel 

```
── concatipede 1.0.0: NOTE

  Build ID:   concatipede_1.0.0.tar.gz-a425303f8788454da96c2f27522b92b4
  Platform:   Fedora Linux, R-devel, clang, gfortran
  Submitted:  20m 23.3s ago
  Build time: 19m 26.1s

❯ checking CRAN incoming feasibility ... NOTE
  Maintainer: ‘Matteo Vecchi <matteo.vecchi15@gmail.com>’
  
  New submission
  
  Possibly mis-spelled words in DESCRIPTION:
    Fasta (2:30)

❯ checking examples ... NOTE
  Examples with CPU (user + system) or elapsed time > 5s
                   user system elapsed
  auto_match_seqs 7.421  0.227    1.91

0 errors ✔ | 0 warnings ✔ | 2 notes ✖
```

## Check for windows-x86_64-devel 

```
── concatipede 1.0.0: NOTE

  Build ID:   concatipede_1.0.0.tar.gz-e63e99a2ef014c9e9de8e818443ed947
  Platform:   Windows Server 2008 R2 SP1, R-devel, 32/64 bit
  Submitted:  5m 18.8s ago
  Build time: 4m 39.5s

❯ checking CRAN incoming feasibility ... NOTE
  Maintainer: 'Matteo Vecchi <matteo.vecchi15@gmail.com>'
  
  New submission
  Possibly mis-spelled words in DESCRIPTION:
  
    Fasta (2:30)

0 errors ✔ | 0 warnings ✔ | 1 note ✖
```

## Check for macos-highsierra-release 

```
── concatipede 1.0.0: OK

  Build ID:   concatipede_1.0.0.tar.gz-55951f3e4bec4199b6dd2de397fea7d6
  Platform:   macOS 10.13.6 High Sierra, R-release, brew
  Submitted:  2m 16.7s ago
  Build time: 1m 22.3s

0 errors ✔ | 0 warnings ✔ | 0 notes ✔
```

## Check for ubuntu-gcc-release 

```
── concatipede 1.0.0: NOTE

  Build ID:   concatipede_1.0.0.tar.gz-4856c646fca54aedbbe94192aa27fb49
  Platform:   Ubuntu Linux 20.04.1 LTS, R-release, GCC
  Submitted:  18m 23.1s ago
  Build time: 17m 40.4s

❯ checking CRAN incoming feasibility ... NOTE
  Maintainer: ‘Matteo Vecchi <matteo.vecchi15@gmail.com>’
  
  New submission
  
  Possibly mis-spelled words in DESCRIPTION:
    Fasta (2:30)

0 errors ✔ | 0 warnings ✔ | 1 note ✖
```

# End of report, 2021-07-31 22:53:13 
