### PR TITLE
Address notes about `LazyData` in `DESCRIPTION` and the possibly invalid URIs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,6 @@ License: MIT + file LICENSE
 URL: https://github.com/tardipede/concatipede, https://tardipede.github.io/concatipede/
 BugReports: https://github.com/tardipede/concatipede/issues
 Encoding: UTF-8
-LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
 Imports:

--- a/vignettes/Package-usage.Rmd
+++ b/vignettes/Package-usage.Rmd
@@ -66,9 +66,7 @@ library(DT)
 library(tidyverse)
 ```
 
-[![](template.png)](template.png)
-
-*(You can click on Excel screenshots to view them larger.)*
+![template](template.png)
 
 ## Modify the correspondence table
 
@@ -80,7 +78,7 @@ You can copy and save different versions of the correspondence table in differen
 
 After modifying the template to specify the correct matches for concatenation, the first sheet of our example excel file now looks like this:
 
-[![](edited_1.png)](edited_1.png)
+![edited_1](edited_1.png)
 
 <div class="alert-primary" role="alert">
 
@@ -106,7 +104,7 @@ image(concatipede(filename = "Macrobiotidae_seqnames.xlsx",out="Macrobiotidae_4g
 
 We can also choose a subset of the taxa from a correspondence table, stored as a separate sheet in the excel file. For example, we can ask `concatipede()` to use the second sheet of the Excel file below when performing the concatenation. This sheet only contains data for the Macrobiotus taxa.
 
-[![](edited_2.png)](edited_2.png)
+![edited_2](edited_2.png)
 
 ```{r message = FALSE}
 concatipede(filename = "Macrobiotidae_seqnames.xlsx",out="Macrobiotus_4genes",excel.sheet = 2)
@@ -119,7 +117,7 @@ image(concatipede(filename = "Macrobiotidae_seqnames.xlsx",out="Macrobiotus_4gen
 
 Here is another example in which we select only one marker, stored in the "COI" sheet of the Excel file:
 
-[![](edited_3.png)](edited_3.png)
+![edited_3](edited_3.png)
 
 ```{r message = FALSE}
 concatipede(filename = "Macrobiotidae_seqnames.xlsx",out="Macrobiotidae_COI",excel.sheet = 3)


### PR DESCRIPTION
I removed the LazyData line in `DESCRIPTION` and I altered the way Excel screenshots were inserted in the vignette to avoid the invalid URIs note.

I ran a check with `devtools::check_win_devel()` which only generated the note about it being a new submission and the spelling of "fasta" (https://win-builder.r-project.org/826C2RKs93Xo). Results of rhub checks (below) also show only the new submission bit, the spelling of "fasta", and in one case the slightly long run time of an example.

# Rhub check report, started on 2021-08-01 13:21:22 

## Check for fedora-clang-devel 

```
── concatipede 1.0.0: NOTE

  Build ID:   concatipede_1.0.0.tar.gz-0020018a824b447ab78aa9f527fa5afc
  Platform:   Fedora Linux, R-devel, clang, gfortran
  Submitted:  19m 22.4s ago
  Build time: 19m 9.5s

❯ checking CRAN incoming feasibility ... NOTE
  Maintainer: ‘Matteo Vecchi <matteo.vecchi15@gmail.com>’
  
  New submission
  
  Possibly mis-spelled words in DESCRIPTION:
    Fasta (2:30)

❯ checking examples ... NOTE
  Examples with CPU (user + system) or elapsed time > 5s
                   user system elapsed
  auto_match_seqs 6.931  0.167   1.781

0 errors ✔ | 0 warnings ✔ | 2 notes ✖
```

## Check for windows-x86_64-devel 

```
── concatipede 1.0.0: NOTE

  Build ID:   concatipede_1.0.0.tar.gz-cbaea42a6c6f4f8f9e5d7b73b284d8a8
  Platform:   Windows Server 2008 R2 SP1, R-devel, 32/64 bit
  Submitted:  4m 17.8s ago
  Build time: 4m 13s

❯ checking CRAN incoming feasibility ... NOTE
  Maintainer: 'Matteo Vecchi <matteo.vecchi15@gmail.com>'
  New submission
  
  Possibly mis-spelled words in DESCRIPTION:
  
    Fasta (2:30)

0 errors ✔ | 0 warnings ✔ | 1 note ✖
```

## Check for macos-highsierra-release 

```
── concatipede 1.0.0: OK

  Build ID:   concatipede_1.0.0.tar.gz-a3c602bb612c44a8b17d8814d05ecdc5
  Platform:   macOS 10.13.6 High Sierra, R-release, brew
  Submitted:  2m 17.1s ago
  Build time: 1m 29.7s

0 errors ✔ | 0 warnings ✔ | 0 notes ✔
```

## Check for ubuntu-gcc-release 

```
── concatipede 1.0.0: NOTE

  Build ID:   concatipede_1.0.0.tar.gz-194344c23b084247b5485a821686bbcc
  Platform:   Ubuntu Linux 20.04.1 LTS, R-release, GCC
  Submitted:  18m 23.4s ago
  Build time: 17m 53.6s

❯ checking CRAN incoming feasibility ... NOTE
  Maintainer: ‘Matteo Vecchi <matteo.vecchi15@gmail.com>’
  
  New submission
  
  Possibly mis-spelled words in DESCRIPTION:
    Fasta (2:30)

0 errors ✔ | 0 warnings ✔ | 1 note ✖
```

# End of report, 2021-08-01 14:06:37 
